### PR TITLE
fix compilation errors

### DIFF
--- a/src/hacks.hpp
+++ b/src/hacks.hpp
@@ -273,14 +273,14 @@ class Hacks {
                     reinterpret_cast<void*>(base::getCocos() + std::stoul(addrStr, nullptr, 16)),
                     bytes
                 ).has_error()) {
-                    log::error(fmt::format("Something went wrong when trying to patch \"{}\"", name));
+                    log::error("Something went wrong when trying to patch \"{}\"", name);
                 }
             } else {
                 if (Mod::get()->patch(
                     reinterpret_cast<void*>(base::get() + std::stoul(addrStr, nullptr, 16)),
                     bytes
                 ).has_error()) {
-                    log::error(fmt::format("Something went wrong when trying to patch \"{}\"", name));
+                    log::error("Something went wrong when trying to patch \"{}\"", name);
                 }
             }
         }


### PR DESCRIPTION
geode log functions behave exactly like fmt::format does, there is no need to use fmt::format manually. geode updated to use the actual {fmt} library recently, since log functions expect a compile time string (the format one), it errors with the following `call to immediate function is not a constant expression`