### PR TITLE
Add Auto Safe Mode option

### DIFF
--- a/resources/hacks/global.json
+++ b/resources/hacks/global.json
@@ -25,6 +25,12 @@
         "type": "bool"
     },
     {
+        "name": "Auto Safe Mode",
+        "desc": "Prevents any progress from being made if certain cheats are enabled.",
+        "opcodes": [],
+        "type": "bool"
+    },
+    {
         "name": "Safe Mode",
         "desc": "Pauses any progress from being done on the level.",
         "opcodes": [

--- a/src/Hacks/Global.cpp
+++ b/src/Hacks/Global.cpp
@@ -72,7 +72,7 @@ class $modify(GameObject) {
 // Safe Mode (a just incase)
 class $modify(GJGameLevel) {
     void savePercentage(int p0, bool p1, int p2, int p3, bool p4) {
-        if (!Hacks::isHackEnabled("Safe Mode") || Hacks::isHackEnabled("Enable Patching")) {
+        if (!(Hacks::isHackEnabled("Safe Mode") || isAutoSafeModeActive()) || Hacks::isHackEnabled("Enable Patching")) {
             GJGameLevel::savePercentage(p0, p1, p2, p3, p4);
         }
     }

--- a/src/Hacks/Player.cpp
+++ b/src/Hacks/Player.cpp
@@ -50,7 +50,7 @@ class $modify(PlayerObject) {
 
         // This is here because $modify doesn't want to work
         if (Hacks::isHackEnabled("Suicide") && PlayLayer::get() != nullptr) {
-	        auto playLayer = PlayLayer::get(); //shut!
+            auto playLayer = PlayLayer::get(); //shut!
             playLayer->destroyPlayer(playLayer->m_player1, nullptr);
         }
     }
@@ -137,7 +137,7 @@ class $modify(GJBaseGameLayer) {
 #ifndef GEODE_IS_MACOS
 // Solid Wave Trail
 class $modify(CCDrawNode) {
-	bool drawPolygon(CCPoint *p0, unsigned int p1, const ccColor4F &p2, float p3, const ccColor4F &p4) {
+    bool drawPolygon(CCPoint *p0, unsigned int p1, const ccColor4F &p2, float p3, const ccColor4F &p4) {
         if (!Hacks::isHackEnabled("Solid Wave Trail")) return CCDrawNode::drawPolygon(p0,p1,p2,p3,p4);
         if (p2.r == 1.F && p2.g == 1.F && p2.b == 1.F && p2.a != 1.F) return true; // tried doing just p2.a != 1.F but uh
         this->setBlendFunc(CCSprite::create()->getBlendFunc());

--- a/src/hacks.cpp
+++ b/src/hacks.cpp
@@ -43,3 +43,16 @@ void Hacks::Settings::setSettingValue(SettingHackStruct* settings, const HackIte
     settings->m_hackValues = array;
     Mod::get()->setSavedValue("values", *settings);
 }
+
+bool isAutoSafeModeActive() {
+    bool isAutoSafeModeOn = Hacks::isHackEnabled("Auto Safe Mode");
+
+    if (!isAutoSafeModeOn) return false;
+
+    if (Hacks::getHack("Speedhack")->value.floatValue != 1.0f || Hacks::isHackEnabled("Instant Complete") || Hacks::isHackEnabled("Noclip") ||
+        Hacks::isHackEnabled("No Spikes") || Hacks::isHackEnabled("No Hitbox") || Hacks::isHackEnabled("No Solids") || Hacks::isHackEnabled("Freeze Player") ||
+        Hacks::isHackEnabled("Jump Hack") || Hacks::isHackEnabled("Force Platformer Mode") || Hacks::isHackEnabled("Change Gravity") || Hacks::isHackEnabled("Layout Mode")
+    ) return true;
+
+    return false;
+}

--- a/src/hacks.hpp
+++ b/src/hacks.hpp
@@ -322,3 +322,5 @@ class Hacks {
     }
 };
 #endif
+
+bool isAutoSafeModeActive();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -327,7 +327,7 @@ class $modify(PlayLayer) {
             }
         }
 #ifndef GEODE_IS_MACOS
-        if (Hacks::isHackEnabled("Safe Mode")) {
+        if (Hacks::isHackEnabled("Safe Mode") || isAutoSafeModeActive()) {
             m_isTestMode = true;
         } else {
             m_isTestMode = m_fields->previousTestMode;
@@ -345,7 +345,9 @@ class $modify(PlayLayer) {
             Hacks::isHackEnabled("Instant Complete") ||
             Hacks::isHackEnabled("Force Platformer Mode") ||
             Hacks::isHackEnabled("Change Gravity") ||
-            Hacks::isHackEnabled("Layout Mode")
+            Hacks::isHackEnabled("Layout Mode") ||
+            Hacks::isHackEnabled("No Hitbox") ||
+            Hacks::getHack("Speedhack")->value.floatValue != 1.0f
         ) { // cheating
             if (!m_fields->isCheating) {
                 m_fields->isCheating = true;
@@ -366,7 +368,9 @@ class $modify(PlayLayer) {
         if (Hacks::isHackEnabled("Instant Complete") && m_fields->frame < 5) {
             log::debug("CRIMINAL… criminal… criminal… criminal…");
             // funny message
-            FLAlertLayer::create(nullptr, "Cheater!", "Just a warning, you will be <cr>banned off leaderboards</c> if you use this on rated levels. Consider this your <cy>warning</c>.", "OK", nullptr)->show();
+
+            // Don't show if any form of safe mode is enabled, it gets VERY annoying otherwise
+            if (!(Hacks::isHackEnabled("Safe Mode") || Hacks::isHackEnabled("Auto Safe Mode"))) FLAlertLayer::create(nullptr, "Cheater!", "Just a warning, you will be <cr>banned off leaderboards</c> if you use this on rated levels. Consider this your <cy>warning</c>.", "OK", nullptr)->show();
         }
         float attemptOpacity = Hacks::getHack("Attempt Opacity")->value.floatValue;
         //if (!Hacks::isHackEnabled("Hide Attempts") && attemptOpacity == 1.0F) return PlayLayer::postUpdate(p0);
@@ -440,7 +444,7 @@ class $modify(PlayLayer) {
     }
 #endif
     void levelComplete() {
-        if (!Hacks::isHackEnabled("Safe Mode") || Hacks::isHackEnabled("Enable Patching")) return PlayLayer::levelComplete();
+        if (!(Hacks::isHackEnabled("Safe Mode") || isAutoSafeModeActive()) || Hacks::isHackEnabled("Enable Patching")) return PlayLayer::levelComplete();
         PlayLayer::resetLevel(); // haha
     }
 };


### PR DESCRIPTION
This is a variation of safe mode that only prevents progress if certain hacks have been enabled.

Additional changes:
- `m_fields->isCheating` now becomes true if Speedhack is not equal to 1.0f or if No Hitboxes is enabled
- Cheater FLAlertLayer no longer spams itself in Safe Mode or Auto Safe Mode (gets incredibly laggy)
- Fixed 2 indents randomly being `\t` (hardtab) instead of 4 spaces