### PR TITLE
Add option to choose number of decimal digits when using Accurate Percentage.

### DIFF
--- a/resources/hacks/global.json
+++ b/resources/hacks/global.json
@@ -41,12 +41,22 @@
     },
     {
         "name": "Accurate Percentage",
-        "desc": "Allows for decimals in the level percentage. [Beyond thousandths place]",
+        "desc": "Allows for decimals in the level percentage.",
         "opcodes": [
             {"addr": "0x208114", "on": "C7 02 25 66 25 25 8B 87 C0 03 00 00 8B B0 04 01 00 00 F3 0F 5A C0 83 EC 08 F2 0F 11 04 24 83 EC 04 89 14 24 90", "off": "F3 0F 2C C0 85 C0 0F 4F C8 B8 64 00 00 00 3B C8 0F 4F C8 8B 87 C0 03 00 00 51 68 30 32 69 00 8B B0 04 01 00 00"},
             {"addr": "0x20813F", "on": "83 C4 0C", "off": "83 C4 08"}
         ],
         "type": "bool"
+    },
+    {
+        "name": "Extra Percent Digits",
+        "desc": "Number of extra decimal digits to be displayed with Accurate Percentage.",
+        "opcodes": [],
+        "type": "int",
+        "min": 1,
+        "max": 15,
+        "step": 1,
+        "default": 4
     },
     {
         "name": "Layout Mode",

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -438,7 +438,10 @@ class $modify(PlayLayer) {
         if (Hacks::isHackEnabled("Enable Patching")) return;
         if (Hacks::isHackEnabled("Accurate Percentage")) {
             if (m_fields->percentLabel == nullptr) return;
-            std::string percentStr = std::to_string(PlayLayer::getCurrentPercent()) + "%";
+            std::stringstream percentStream;
+            int numDigits = Hacks::getHack("Extra Percent Digits")->value.intValue;
+            percentStream << std::fixed << std::setprecision(numDigits) << PlayLayer::getCurrentPercent() << "%";
+            std::string percentStr = percentStream.str();
             m_fields->percentLabel->setString(percentStr.c_str());
         }
     }


### PR DESCRIPTION
Exactly what it sounds like- adds a slider below the button for the "Accurate Percentage" hack that allows the user to choose a specific number of digits following the decimal in the percentage.