### PR TITLE
Show hitbox and related hacks

### DIFF
--- a/resources/hacks/misc.json
+++ b/resources/hacks/misc.json
@@ -35,5 +35,26 @@
         "opcodes": [],
         "type": "button",
         "default": "button"
+    },
+    {
+        "name": "Show Hitboxes",
+        "desc": "Show player, obstacle, and solid hitboxes.",
+        "opcodes": [],
+        "type": "bool"
+    },
+    {
+        "name": "Hitbox Stroke",
+        "desc": "Stroke 'width' when drawing hitboxes",
+        "opcodes": [],
+        "type": "float",
+        "min": 0.1,
+        "max": 10,
+        "default": 1
+    },
+    {
+        "name": "Show Hitboxes on Death",
+        "desc": "Shows hitboxes when you die, and hides them when you respawn.",
+        "opcodes": [],
+        "type": "bool"
     }
 ]

--- a/resources/hacks/player.json
+++ b/resources/hacks/player.json
@@ -111,5 +111,26 @@
         "min": -5,
         "max": 5,
         "default": 1
+    },
+    {
+        "name": "Show Hitboxes",
+        "desc": "Show player, obstacle, and solid hitboxes.",
+        "opcodes": [],
+        "type": "bool"
+    },
+    {
+        "name": "Hitbox Stroke",
+        "desc": "Stroke 'width' when drawing hitboxes",
+        "opcodes": [],
+        "type": "float",
+        "min": 0.1,
+        "max": 10,
+        "default": 1
+    },
+    {
+        "name": "Show Hitboxes on Death",
+        "desc": "Shows hitboxes when you die, and hides them when you respawn.",
+        "opcodes": [],
+        "type": "bool"
     }
 ]

--- a/resources/hacks/player.json
+++ b/resources/hacks/player.json
@@ -111,26 +111,5 @@
         "min": -5,
         "max": 5,
         "default": 1
-    },
-    {
-        "name": "Show Hitboxes",
-        "desc": "Show player, obstacle, and solid hitboxes.",
-        "opcodes": [],
-        "type": "bool"
-    },
-    {
-        "name": "Hitbox Stroke",
-        "desc": "Stroke 'width' when drawing hitboxes",
-        "opcodes": [],
-        "type": "float",
-        "min": 0.1,
-        "max": 10,
-        "default": 1
-    },
-    {
-        "name": "Show Hitboxes on Death",
-        "desc": "Shows hitboxes when you die, and hides them when you respawn.",
-        "opcodes": [],
-        "type": "bool"
     }
 ]

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,6 +155,7 @@ CircleButtonSprite* createCheatIndicator(bool isHacking) {
     return cheatIndicator;
 }
 
+#ifdef GEODE_IS_WINDOWS
 void drawPlayerHitboxes(CCDrawNode* drawNode, PlayerObject* player) {
     auto innerRect = player->getObjectRect(0.25f, 0.25f);
     drawNode->drawRect(
@@ -178,6 +179,7 @@ void drawPlayerHitboxes(CCDrawNode* drawNode, PlayerObject* player) {
             1000
     );
 }
+#endif
 
 class $modify(PlayLayer) {
     float previousPositionX = 0.0F;
@@ -471,7 +473,7 @@ class $modify(PlayLayer) {
     }
 
     // Show Hitboxes
-#ifndef GEODE_IS_MACOS
+#ifdef GEODE_IS_WINDOWS
     void updateVisibility(float p0) {
         PlayLayer::updateVisibility(p0);
         if (Hacks::isHackEnabled("Show Hitboxes") || (Hacks::isHackEnabled("Show Hitboxes on Death") && m_player1->m_isDead)) {
@@ -486,7 +488,7 @@ class $modify(PlayLayer) {
 
 };
 
-#ifndef GEODE_IS_MACOS // Show Hitboxes
+#ifdef GEODE_IS_WINDOWS // Show Hitboxes
 
 #include <Geode/modify/LevelEditorLayer.hpp>
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -331,7 +331,6 @@ class $modify(PlayLayer) {
     }
     void postUpdate(float p0) {
         PlayLayer::postUpdate(p0);
-
         if (m_player1 != nullptr) {
             if (m_player1->getPositionX() != m_fields->previousPlayerX) {
                 m_fields->previousPlayerX = m_player1->getPositionX();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -515,7 +515,11 @@ class $modify(CCDrawNode) {
     bool drawPolygon(cocos2d::CCPoint* p0, unsigned int p1, const cocos2d::ccColor4F& p2,
                      float stroke, const cocos2d::ccColor4F& p4) {
         auto playLayer = PlayLayer::get();
-        if (playLayer && this == playLayer->m_debugDrawNode)
+        auto editLayer = LevelEditorLayer::get();
+        GJBaseGameLayer* baseLayer = nullptr;
+        if (playLayer) baseLayer = typeinfo_cast<GJBaseGameLayer*>(playLayer);
+        else if (editLayer) baseLayer = typeinfo_cast<GJBaseGameLayer*>(editLayer);
+        if (baseLayer && this == baseLayer->m_debugDrawNode)
             stroke *= Hacks::getHack("Hitbox Stroke")->value.floatValue;
         return CCDrawNode::drawPolygon(p0, p1, p2, stroke, p4);
     }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -155,6 +155,30 @@ CircleButtonSprite* createCheatIndicator(bool isHacking) {
     return cheatIndicator;
 }
 
+void drawPlayerHitboxes(CCDrawNode* drawNode, PlayerObject* player) {
+    auto innerRect = player->getObjectRect(0.25f, 0.25f);
+    drawNode->drawRect(
+            CCPoint(innerRect.getMinX(), innerRect.getMinY()),
+            CCPoint(innerRect.getMaxX(), innerRect.getMaxY()),
+            ccColor4F(0.0f, 0.0f, 0.0f, 0.0f),
+            0.25f, ccColor4F(0.0f, 0.0f, 1.0f, 1.0f)
+    );
+    auto outerRect = player->getObjectRect();
+    drawNode->drawRect(
+            CCPoint(outerRect.getMinX(), outerRect.getMinY()),
+            CCPoint(outerRect.getMaxX(), outerRect.getMaxY()),
+            ccColor4F(0.0f, 0.0f, 0.0f, 0.0f),
+            0.25f, ccColor4F(1.0f, 0.0f, 0.0f, 1.0f)
+    );
+    drawNode->drawCircle(
+            CCPoint(outerRect.getMidX(), outerRect.getMidY()),
+            outerRect.getMaxX() - outerRect.getMidX(),
+            ccColor4F(0.0f, 0.0f, 0.0f, 0.0f),
+            0.25f, ccColor4F(1.0f, 0.2f, 0.2f, 1.0f),
+            1000
+    );
+}
+
 class $modify(PlayLayer) {
     float previousPositionX = 0.0F;
     GameObject* antiCheatObject; // removing after lol
@@ -239,11 +263,6 @@ class $modify(PlayLayer) {
         if (Hacks::isHackEnabled("Instant Complete")) {
             PlayLayer::playEndAnimationToPos({2,2});
         }
-        /*
-        if (Hacks::isHackEnabled("Show Hitboxes")) {
-            PlayLayer::toggleDebugDraw(false);
-        }
-        */
         
         // 0xaa9
         int targetValue = true;
@@ -312,6 +331,7 @@ class $modify(PlayLayer) {
     }
     void postUpdate(float p0) {
         PlayLayer::postUpdate(p0);
+
         if (m_player1 != nullptr) {
             if (m_player1->getPositionX() != m_fields->previousPlayerX) {
                 m_fields->previousPlayerX = m_player1->getPositionX();
@@ -450,7 +470,59 @@ class $modify(PlayLayer) {
         if (!(Hacks::isHackEnabled("Safe Mode") || isAutoSafeModeActive()) || Hacks::isHackEnabled("Enable Patching")) return PlayLayer::levelComplete();
         PlayLayer::resetLevel(); // haha
     }
+
+    // Show Hitboxes
+#ifndef GEODE_IS_MACOS
+    void updateVisibility(float p0) {
+        PlayLayer::updateVisibility(p0);
+        if (Hacks::isHackEnabled("Show Hitboxes") || (Hacks::isHackEnabled("Show Hitboxes on Death") && m_player1->m_isDead)) {
+            if (!m_debugDrawNode->isVisible()) m_debugDrawNode->setVisible(true);
+            PlayLayer::updateDebugDraw();
+            drawPlayerHitboxes(m_debugDrawNode, m_player1);
+        }
+        else if (m_debugDrawNode->isVisible() && !(m_isPracticeMode && m_isDebugDrawEnabled))
+            m_debugDrawNode->setVisible(false);
+    }
+#endif
+
 };
+
+#ifndef GEODE_IS_MACOS // Show Hitboxes
+
+#include <Geode/modify/LevelEditorLayer.hpp>
+
+inline void showLevelEditorHitboxes(LevelEditorLayer* ptr, bool mode) {
+    GameManager::get()->setGameVariable("0045", mode);
+    ptr->m_isDebugDrawEnabled = mode;
+}
+
+class $modify(LevelEditorLayer) {
+    bool lastShowHitboxes = false;
+    void updateVisibility(float p0) {
+        LevelEditorLayer::updateVisibility(p0);
+        bool showHitboxes = Hacks::isHackEnabled("Show Hitboxes");
+        if (showHitboxes) {
+            if (!m_isDebugDrawEnabled) showLevelEditorHitboxes(this, true);
+            drawPlayerHitboxes(m_debugDrawNode, m_player1);
+        }
+        else if (showHitboxes != m_fields->lastShowHitboxes)
+            showLevelEditorHitboxes(this, false);
+        m_fields->lastShowHitboxes = showHitboxes;
+    }
+};
+
+#include <Geode/modify/CCDrawNode.hpp>
+class $modify(CCDrawNode) {
+    bool drawPolygon(cocos2d::CCPoint* p0, unsigned int p1, const cocos2d::ccColor4F& p2,
+                     float stroke, const cocos2d::ccColor4F& p4) {
+        auto playLayer = PlayLayer::get();
+        if (playLayer && this == playLayer->m_debugDrawNode)
+            stroke *= Hacks::getHack("Hitbox Stroke")->value.floatValue;
+        return CCDrawNode::drawPolygon(p0, p1, p2, stroke, p4);
+    }
+};
+
+#endif
 
 /*
 class $modify(PlayLayer) {
@@ -465,8 +537,3 @@ class $modify(PlayLayer) {
     }*\/ // WHY YOU HAVE DELAY
 };
 */
-
-
-
-
-


### PR DESCRIPTION
Implemented here:
* Show Hitboxes
* Show Hitboxes on Death
* Custom stroke when drawing hitboxes

I don't have access to MacOS and this relies on [these](https://github.com/geode-sdk/bindings/pull/229) bindings that I added a very short time ago and don't currently have a mac equivalent, so no mac support. average mac experience I guess

They're all under the misc category; not sure where else to put them

I've done about 10 minutes worth of testing so hopefully there's no bugs here because yeah