### PR TITLE
Polish Quartz Bot, Auto Clicker and Clicks per second translations + Credits for the translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Press on the circle button located on the left corner, or press `Tab` to open th
 * [RzaIX](https://twitter.com/RzaIX_) - Translations for Indonesian
 * KONDIROTSU - Translations for Polish
 * olaf_294 - Translations for Polish
+* Pan Polak - Translations for Polish
 * hori - Translations for Malay
 * slideglide - Translations for Turkish
 * DarkKing - Proofreading for Turkish

--- a/about.md
+++ b/about.md
@@ -43,6 +43,7 @@ Press on the circle button located on the left corner, or press `Tab` to open th
 * [RzaIX](https://twitter.com/RzaIX_) - Translations for Indonesian
 * KONDIROTSU - Translations for Polish
 * olaf_294 - Translations for Polish
+* Pan Polak - Translations for Polish
 * hori - Translations for Malay
 * slideglide - Translations for Turkish
 * DarkKing - Proofreading for Turkish

--- a/resources/hacks/settings.json
+++ b/resources/hacks/settings.json
@@ -20,7 +20,7 @@
         "desc": "Sets the language for Prism Menu!",
         "type": "dropdown",
         "default": 0,
-        "values": ["English", "Français", "Português (Brasil)", "Deutsch", "Русский", "Čeština", "Indonesia", "Español", "Polskie", "Melayu", "Türkçe", "Tieng Viet", "Українська","Italiano","Română"],
+        "values": ["English", "Français", "Português (Brasil)", "Deutsch", "Русский", "Čeština", "Indonesia", "Español", "Polski", "Melayu", "Türkçe", "Tieng Viet", "Українська","Italiano","Română"],
         "todovalues": ["Ελληνική","日本語"]
     },
     {

--- a/resources/langs/polish.json
+++ b/resources/langs/polish.json
@@ -20,6 +20,11 @@
         }
     },
     {
+        "¦ Quartz Bot": {
+            "name": "¦ Quartz Bot"
+        }
+    },
+    {
         "··· Misc": {
             "name": "··· Inne"
         }
@@ -507,6 +512,54 @@
         "Suicide": {
             "name": "Samobójstwo",
             "desc": "Zabija gracza bez przerywania."
+        }
+    },
+    {
+        "Macro": {
+            "name": "Makro",
+            "desc": "Wybierz Makro Które chcesz Nagrać Lub Odtworzyć!"
+        }
+    },
+    {
+        "Record": {
+            "name": "Nagraj",
+            "desc": "Nagrywa Rozrywkę Którą potem możesz odtworzyć (To Zresetuje Wejścia Jeśli wejdziesz w poziom i masz wybrane makro)"
+        }
+    },
+    {
+        "Playback": {
+            "name": "Odtwórz",
+            "desc": "Odtwarza Makro Spowrotem"
+        }
+    },
+    {
+        "Macro Editor": {
+            "name": "Edytor Makro",
+            "desc": "Wejdź w Edytor Makra. (Nie Będzie dobrze działać jeśli masz włączone nagrywanie makra)"
+        }
+    },
+    {
+        "Frame Fix": {
+            "name": "Naprawa Klatek",
+            "desc": "Nagrywa Każdy ruch gracza, łącznie z pozycją jeśli nagrywasz i odtwarzasz makro spowrotem. Ale może to zwiększyć rozmiar makra podczas nagrywania"
+        }
+    },
+    {
+        "Fixed FPS": {
+            "name": "Naprawione Klatki",
+            "desc": "Blokuje Klatki do Celowanej liczby klatek na sekundę makra. To może wyglądać jak \"smooth fix\" opcja jest włączona jeśli gra się zacina"
+        }
+    },
+    {
+        "Import Macro": {
+            "name": "Importuj Makro",
+            "desc": "Importuje Makro"
+        }
+    },
+    {
+        "Save Macro": {
+            "name": "Zapisz Makro",
+            "desc": "Zapisuje Makro"
         }
     }
 ]

--- a/resources/langs/polish.json
+++ b/resources/langs/polish.json
@@ -571,7 +571,7 @@
     {
         "Clicks per second": {
             "name": "Kliknięcia na sekundę",
-            "desc": "Liczba kliknięć auto clickera na sekundę"
+            "desc": " Liczba kliknięć Którą auto clicker ma kliknąć na sekundę"
         }
     }
 ]

--- a/resources/langs/polish.json
+++ b/resources/langs/polish.json
@@ -561,5 +561,17 @@
             "name": "Zapisz Makro",
             "desc": "Zapisuje Makro"
         }
+    },
+    {
+        "Auto Clicker": {
+            "name": "Automatyczny klikacz",
+            "desc": "Automatycznie Klika za ciebie"
+        }
+    },
+    {
+        "Clicks per second": {
+            "name": "Kliknięcia na sekundę",
+            "desc": "Liczba kliknięć auto clickera na sekundę"
+        }
     }
 ]

--- a/src/UI/CreditsMenu.cpp
+++ b/src/UI/CreditsMenu.cpp
@@ -358,6 +358,17 @@ std::vector<CreditUser> users = {
         true,
         "",
         28982364
+    },
+    {
+        "Pan Polak",
+        379,
+        "Translator (PL)",
+        { 255, 255, 255 },
+        { 0, 255, 255 },
+        { 255, 255, 255 },
+        true,
+        "",
+        20527327
     }
 };
 


### PR DESCRIPTION
this pull request adds Polish translations to Quartz Bot, Auto Clicker and Clicks per second with credits for the person that translated it (Pan Polak)

please test if the icon colors are correct in the credits menu, it should look like this. i cant test because actions does not work
![image](https://github.com/user-attachments/assets/616ad9ed-78b9-4840-92be-b761143e2fcb)

forgot to mention, this pull request also changes the language name from "Polskie" to "Polski" because it is incorrect apparently
