### PR TITLE
(TR) Fix Wave Pulse Size description suffix typo

### DIFF
--- a/resources/langs/turkish.json
+++ b/resources/langs/turkish.json
@@ -591,7 +591,7 @@
   {
     "Wave Pulse Size": {
       "name": "Wave İzi Boyutu",
-      "desc": "Wave izinin boyutunu ayarlamınızı sağlar."
+      "desc": "Wave izinin boyutunu ayarlamanızı sağlar."
     }
   },
   {


### PR DESCRIPTION
how did i miss this!

![image](https://github.com/user-attachments/assets/67979954-431f-4101-855e-d3b3c084d07a)
